### PR TITLE
Release 0.8.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,5 +1,5 @@
 0.8.0 (2016-05-15)
-+++++++++++
+++++++++++++++++++
 
 * Fork from dce_lti_py_, and rename to ``lti`` at version 0.7.4.
 * Convert text files to reStructured Text.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,9 @@
-0.8.0 (TBD)
+0.8.0 (2016-05-15)
 +++++++++++
 
 * Fork from dce_lti_py_, and rename to ``lti`` at version 0.7.4.
+* Convert text files to reStructured Text.
+* Use README as PyPI long description.
 
 .. _dce_lti_py: https://github.com/harvard-dce/dce_lti_py
 

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
     name='lti',
     version='0.8.0',
     description='A python library for building and/or consuming LTI apps',
+    long_description=open('README.rst', 'rb').read().decode('utf-8'),
     author='Python LTI Initiative',
     url='https://github.com/pylti/lti',
     package_dir={'': 'src'},


### PR DESCRIPTION
* Fork from `dce_lti_py`, and rename to `lti` at version 0.7.4.
* Convert text files to reStructured Text.
* Use README as PyPI long description.