### PR TITLE
Build tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ after_success: codecov
 branches:
   only:
     - master
+    - /^.*$/
 deploy:
   provider: pypi
   user: pylti

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ python:
 install: pip install tox-travis codecov
 script: tox
 after_success: codecov
+branches:
+  only:
+    - master
 deploy:
   provider: pypi
   user: pylti


### PR DESCRIPTION
Deployments are done based on tags. If they aren't built on Travis, then the deployment doesn't happen. The quick fix was to just build every push, but this is a cleaner fix that doesn't cause double building of pull requests.