### PR TITLE
Coverage should only count package code

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,6 @@
 [coverage:run]
 branch = True
-source =
-    lti
-    tests/
+source = lti
 
 [coverage:paths]
 source =


### PR DESCRIPTION
This will make the code coverage go down, because the tests are counted as fully covered. This is expected.