### PR TITLE
Get tool config tests passing

### DIFF
--- a/src/lti/tool_config.py
+++ b/src/lti/tool_config.py
@@ -27,7 +27,7 @@ NSMAP = {
     'lticm': 'http://www.imsglobal.org/xsd/imslticm_v1p0',
     }
 
-class ToolConfig():
+class ToolConfig(object):
     '''
     Object used to represent LTI configuration.
 
@@ -176,19 +176,19 @@ class ToolConfig():
                 self.set_ext_params(platform, properties)
 
     def recursive_options(self,element,params):
-        for key, val in params.items():
+        for key, val in sorted(params.items()):
             if isinstance(val, dict):
                 options_node = etree.SubElement(element,
                       '{%s}%s' %(NSMAP['lticm'], 'options'), name =
                       key)
-                for key, val in val.items():
+                for key, val in sorted(val.items()):
                     self.recursive_options(options_node,{key:val})
             else:
                 param_node = etree.SubElement(element, '{%s}%s'
                           %(NSMAP['lticm'], 'property'), name = key)
                 param_node.text = val
 
-    def to_xml(self, opts = defaultdict(lambda: None)):
+    def to_xml(self, opts=defaultdict(lambda: None)):
         '''
         Generate XML from the current settings.
         '''
@@ -250,4 +250,5 @@ class ToolConfig():
             identifierref = etree.SubElement(root, 'cartridge_icon',
                     identifierref = self.cartridge_icon)
 
-        return '<?xml version="1.0" encoding="UTF-8"?>' + etree.tostring(root)
+        declaration = b'<?xml version="1.0" encoding="UTF-8"?>'
+        return declaration + etree.tostring(root, encoding='utf-8')

--- a/tests/test_tool_config.py
+++ b/tests/test_tool_config.py
@@ -2,7 +2,7 @@ from lti import ToolConfig, InvalidLTIConfigError
 from lxml import etree
 import unittest
 
-CC_LTI_XML = '''<?xml version="1.0" encoding="UTF-8"?>
+CC_LTI_XML = b'''<?xml version="1.0" encoding="UTF-8"?>
 <cartridge_basiclti_link xmlns:blti="http://www.imsglobal.org/xsd/imsbasiclti_v1p0" xmlns:lticm="http://www.imsglobal.org/xsd/imslticm_v1p0" xmlns:lticp="http://www.imsglobal.org/xsd/imslticp_v1p0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.imsglobal.org/xsd/imslticc_v1p0" xsi:schemaLocation="http://www.imsglobal.org/xsd/imslticc_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticc_v1p0.xsd http://www.imsglobal.org/xsd/imsbasiclti_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imsbasiclti_v1p0p1.xsd http://www.imsglobal.org/xsd/imslticm_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticm_v1p0.xsd http://www.imsglobal.org/xsd/imslticp_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticp_v1p0.xsd">
     <blti:title>Test Config</blti:title>
     <blti:description>Description of boringness</blti:description>
@@ -24,11 +24,11 @@ CC_LTI_XML = '''<?xml version="1.0" encoding="UTF-8"?>
     </blti:custom>
     <blti:extensions platform="example.com">
         <lticm:property name="extkey1">extval1</lticm:property>
-        <lticm:options name="extopt1">
-            <lticm:property name="optkey2">optval2</lticm:property>
-            <lticm:property name="optkey1">optval1</lticm:property>
-        </lticm:options>
         <lticm:property name="extkey2">extval2</lticm:property>
+        <lticm:options name="extopt1">
+            <lticm:property name="optkey1">optval1</lticm:property>
+            <lticm:property name="optkey2">optval2</lticm:property>
+        </lticm:options>
     </blti:extensions>
     <blti:extensions platform="two.example.com">
         <lticm:property name="ext1key">ext1val</lticm:property>
@@ -37,7 +37,7 @@ CC_LTI_XML = '''<?xml version="1.0" encoding="UTF-8"?>
 </cartridge_basiclti_link>
 '''
 
-CC_LTI_WITH_SUBOPTIONS_XML = '''<?xml version="1.0" encoding="UTF-8"?>
+CC_LTI_WITH_SUBOPTIONS_XML = b'''<?xml version="1.0" encoding="UTF-8"?>
 <cartridge_basiclti_link xmlns:blti="http://www.imsglobal.org/xsd/imsbasiclti_v1p0" xmlns:lticm="http://www.imsglobal.org/xsd/imslticm_v1p0" xmlns:lticp="http://www.imsglobal.org/xsd/imslticp_v1p0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.imsglobal.org/xsd/imslticc_v1p0" xsi:schemaLocation="http://www.imsglobal.org/xsd/imslticc_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticc_v1p0.xsd http://www.imsglobal.org/xsd/imsbasiclti_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imsbasiclti_v1p0p1.xsd http://www.imsglobal.org/xsd/imslticm_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticm_v1p0.xsd http://www.imsglobal.org/xsd/imslticp_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticp_v1p0.xsd">
     <blti:title>Test Config</blti:title>
     <blti:description>Description of boringness</blti:description>
@@ -59,13 +59,13 @@ CC_LTI_WITH_SUBOPTIONS_XML = '''<?xml version="1.0" encoding="UTF-8"?>
     </blti:custom>
     <blti:extensions platform="example.com">
         <lticm:property name="extkey1">extval1</lticm:property>
+        <lticm:property name="extkey2">extval2</lticm:property>
         <lticm:options name="extopt1">
             <lticm:options name="labels">
                 <lticm:property name="en">Image Library</lticm:property>
                 <lticm:property name="es">Biblioteca de Imagenes</lticm:property>
             </lticm:options>
         </lticm:options>
-        <lticm:property name="extkey2">extval2</lticm:property>
     </blti:extensions>
     <blti:extensions platform="two.example.com">
         <lticm:property name="ext1key">ext1val</lticm:property>


### PR DESCRIPTION
Sort all output parameters to ensure a consistent output order. Since the output includes the encoding header, use bytes.