### PR TITLE
removed xml decliration from in front of etree.tostring return

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ venv
 
 # Coverage
 .coverage*
+
+# Pycharm
+.idea

--- a/src/lti/outcome_response.py
+++ b/src/lti/outcome_response.py
@@ -163,4 +163,4 @@ class OutcomeResponse():
             text_string = etree.SubElement(result_score, 'textString')
             text_string.text = str(self.score)
 
-        return '<?xml version="1.0" encoding="UTF-8"?>' + etree.tostring(root)
+        return etree.tostring(root, xml_declaration=True)

--- a/tests/test_outcome_response.py
+++ b/tests/test_outcome_response.py
@@ -3,7 +3,7 @@ from lxml import etree
 import mock
 import unittest
 
-RESPONSE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+RESPONSE_XML = """
 <imsx_POXEnvelopeResponse xmlns="http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0">
     <imsx_POXHeader>
         <imsx_POXResponseHeaderInfo>
@@ -27,7 +27,7 @@ RESPONSE_XML = """<?xml version="1.0" encoding="UTF-8"?>
 def normalize_xml(xml_str):
     parser = etree.XMLParser(remove_blank_text=True)
     root = etree.XML(xml_str, parser)
-    return etree.tostring(root, with_tail=False)
+    return etree.tostring(root, with_tail=False, xml_declaration=True)
 
 class TestOutcomeResponse(unittest.TestCase):
 
@@ -55,8 +55,8 @@ class TestOutcomeResponse(unittest.TestCase):
         '''
         Should parse readResult response XML.
         '''
-        read_xml = RESPONSE_XML.replace(\
-                '<replaceResultResponse/>',\
+        read_xml = RESPONSE_XML.replace(
+                '<replaceResultResponse/>',
                 '''<readResultResponse>
 <result>
 <resultScore>


### PR DESCRIPTION
Removing the xml declaration string in front of `etree.tostring()` return in outcome_response, and switching it to the built in param fixed "ValueError: Unicode strings with encoding declarations are not supported. Please use bytes input or XML fragments without declaration." errors