### PR TITLE
Do not require secret for tool provider

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,8 +98,7 @@ Tool Provider OAuth Request Validation Example (Django)
 
 
     # create the tool provider instance
-    secret = 'my LTI app oauth secret'
-    tool_provider = DjangoToolProvider.from_django_request(secret, request)
+    tool_provider = DjangoToolProvider.from_django_request(request=request)
 
     # the tool provider uses the 'oauthlib' library which requires an instance
     # of a validator class when doing the oauth request signature checking.

--- a/src/lti/contrib/django/django_tool_provider.py
+++ b/src/lti/contrib/django/django_tool_provider.py
@@ -7,7 +7,10 @@ class DjangoToolProvider(ToolProvider):
     ToolProvider that works with Django requests
     '''
     @staticmethod
-    def from_django_request(secret, request):
+    def from_django_request(secret=None, request=None):
+        if request is None:
+            raise ValueError('request must be supplied')
+
         params = request.POST.copy()
         # django shoves a bunch of other junk in META that we don't care about
         headers = dict([(k, request.META[k])

--- a/src/lti/contrib/django/django_tool_provider.py
+++ b/src/lti/contrib/django/django_tool_provider.py
@@ -6,8 +6,8 @@ class DjangoToolProvider(ToolProvider):
     '''
     ToolProvider that works with Django requests
     '''
-    @staticmethod
-    def from_django_request(secret=None, request=None):
+    @classmethod
+    def from_django_request(cls, secret=None, request=None):
         if request is None:
             raise ValueError('request must be supplied')
 
@@ -18,7 +18,7 @@ class DjangoToolProvider(ToolProvider):
                         k.upper().startswith('HTTP_') or \
                         k.upper().startswith('CONTENT_')])
         url = request.build_absolute_uri()
-        return ToolProvider.from_unpacked_request(secret, params, url, headers)
+        return cls.from_unpacked_request(secret, params, url, headers)
 
     def success_redirect(self, msg='', log=''):
         '''

--- a/src/lti/contrib/flask/flask_tool_provider.py
+++ b/src/lti/contrib/flask/flask_tool_provider.py
@@ -5,7 +5,10 @@ class FlaskToolProvider(ToolProvider):
     ToolProvider that works with Flask requests
     '''
     @staticmethod
-    def from_flask_request(secret, request):
+    def from_flask_request(secret=None, request=None):
+        if request is None:
+            raise ValueError('request must be supplied')
+
         params = request.form.copy()
         headers = request.headers.copy()
         url = request.url

--- a/src/lti/contrib/flask/flask_tool_provider.py
+++ b/src/lti/contrib/flask/flask_tool_provider.py
@@ -4,12 +4,12 @@ class FlaskToolProvider(ToolProvider):
     '''
     ToolProvider that works with Flask requests
     '''
-    @staticmethod
-    def from_flask_request(secret=None, request=None):
+    @classmethod
+    def from_flask_request(cls, secret=None, request=None):
         if request is None:
             raise ValueError('request must be supplied')
 
         params = request.form.copy()
         headers = request.headers.copy()
         url = request.url
-        return ToolProvider.from_unpacked_request(secret, params, url, headers)
+        return cls.from_unpacked_request(secret, params, url, headers)

--- a/src/lti/tool_base.py
+++ b/src/lti/tool_base.py
@@ -6,7 +6,7 @@ ROLES_INSTRUCTOR = ['instructor', 'faculty', 'staff']
 
 class ToolBase(object):
 
-    def __init__(self, consumer_key, consumer_secret, params=None):
+    def __init__(self, consumer_key=None, consumer_secret=None, params=None):
 
         self.consumer_key = consumer_key
         self.consumer_secret = consumer_secret


### PR DESCRIPTION
Actually, we want to prefer _not_ having the secret passed in to the provider if at all possible, because it encourages shortcuts when creating the validator that can easily cause timing attacks. Plus, the secret is only really useful to methods dealing with outcomes, so for the general case it's not needed anyway.

Fixes #25