### PR TITLE
Ignore duplicate query params for signature

### DIFF
--- a/src/lti/tool_base.py
+++ b/src/lti/tool_base.py
@@ -4,6 +4,12 @@ from .launch_params import LaunchParams, valid_param
 ROLES_STUDENT = ['student', 'learner']
 ROLES_INSTRUCTOR = ['instructor', 'faculty', 'staff']
 
+try:
+    from urllib.parse import urlencode, urlsplit, urlunsplit, parse_qsl
+except ImportError:
+    # Python 2
+    from urllib import urlencode
+    from urlparse import urlsplit, urlunsplit, parse_qsl
 
 class ToolBase(object):
 
@@ -78,3 +84,23 @@ class ToolBase(object):
             if isinstance(v, list):
                 params[k] = ','.join(v)
         return params
+
+    def signature_launch_url(self):
+        if self.launch_url:
+            params = self.to_params()
+            original = urlsplit(self.launch_url)
+            launch_query = dict(parse_qsl(original.query))
+
+            # remove duplicate parameters from quey string
+            for k, v in launch_query.copy().items():
+                if k in params and params[k] == v:
+                    del launch_query[k]
+
+            return urlunsplit((
+                original.scheme,
+                original.netloc,
+                original.path,
+                urlencode(launch_query),
+                original.fragment
+            ))
+        return None

--- a/src/lti/tool_outbound.py
+++ b/src/lti/tool_outbound.py
@@ -44,7 +44,7 @@ class ToolOutbound(ToolBase):
             )
 
         params = self.to_params()
-        r = Request('POST', self.launch_url, data=params).prepare()
+        r = Request('POST', self.signature_launch_url(), data=params).prepare()
         sign = OAuth1(self.consumer_key, self.consumer_secret,
                                 signature_type=SIGNATURE_TYPE_BODY, **kwargs)
         return sign(r)

--- a/src/lti/tool_provider.py
+++ b/src/lti/tool_provider.py
@@ -51,7 +51,7 @@ class ToolProvider(ToolBase):
         endpoint = SignatureOnlyEndpoint(validator)
 
         valid, request = endpoint.validate_request(
-            self.launch_url,
+            self.signature_launch_url(),
             'POST',
             self.to_params(),
             self.launch_headers

--- a/tests/test_tool_consumer.py
+++ b/tests/test_tool_consumer.py
@@ -105,6 +105,33 @@ class TestToolConsumer(unittest.TestCase):
             })
         self.assertEqual(got, correct)
 
+    def test_launch_request_with_duplicate_qs(self):
+        """
+        test that qs params in launch url are ok
+        """
+        launch_params = {
+            'lti_version': 'abc',
+            'lti_message_type': 'def',
+            'resource_link_id': '123',
+            'custom_value': '123'
+        }
+        tc = ToolConsumer('client_key', 'client_secret',
+                          launch_url='http://example.edu/foo?bar=1&custom_value=123',
+                          params=launch_params)
+        launch_req = tc.generate_launch_request(nonce='wxyz7890',
+                                                timestamp='2345678901')
+        got = parse_qs(unquote(launch_req.body.decode('utf-8')))
+        correct = launch_params.copy()
+        correct.update({
+            'oauth_nonce': 'wxyz7890',
+            'oauth_timestamp': '2345678901',
+            'oauth_version': '1.0',
+            'oauth_signature_method': 'HMAC-SHA1',
+            'oauth_consumer_key': 'client_key',
+            'oauth_signature': 'ICbdppbpNXOFxg1ssMreN6fyH2k=',
+        })
+        self.assertEqual(got, correct)
+
     def test_generate_launch_data(self):
         launch_params = {
             'lti_version': 'abc',


### PR DESCRIPTION
Query string params that also appear in the body can cause signature issues with different LTI consumers/providers

Fixes #50