### PR TITLE
Handling Non-Standard LTI Params

### DIFF
--- a/src/lti/launch_params.py
+++ b/src/lti/launch_params.py
@@ -123,7 +123,7 @@ class LaunchParams(MutableMapping):
 
         # now verify we only got valid launch params
         for k in self.keys():
-            if not valid_param(k):
+            if not self.valid_param(k):
                 raise InvalidLaunchParamError(k)
 
         # enforce some defaults
@@ -144,11 +144,14 @@ class LaunchParams(MutableMapping):
         else:
             return self._params[param]
 
+    def valid_param(self, param):
+        return valid_param(param)
+
     def __len__(self):
         return len(self._params)
 
     def __getitem__(self, item):
-        if not valid_param(item):
+        if not self.valid_param(item):
             raise KeyError("{} is not a valid launch param".format(item))
         try:
             return self._param_value(item)
@@ -157,7 +160,7 @@ class LaunchParams(MutableMapping):
             raise KeyError(item)
 
     def __setitem__(self, key, value):
-        if not valid_param(key):
+        if not self.valid_param(key):
             raise InvalidLaunchParamError(key)
         if key in LAUNCH_PARAMS_IS_LIST:
             if isinstance(value, list):

--- a/src/lti/tool_consumer.py
+++ b/src/lti/tool_consumer.py
@@ -57,7 +57,7 @@ class ToolConsumer(ToolBase):
         """
 
         r = self.generate_launch_request(**kwargs)
-        return parse_qs(unquote(r.body.decode('utf-8')))
+        return parse_qs(r.body.decode('utf-8'))
 
     def set_config(self, config):
         '''

--- a/src/lti/tool_provider.py
+++ b/src/lti/tool_provider.py
@@ -21,11 +21,12 @@ class ToolProvider(ToolBase):
     '''
     Implements the LTI Tool Provider.
     '''
+    launch_params_class = LaunchParams
 
     @classmethod
     def from_unpacked_request(cls, secret, params, url, headers):
 
-        launch_params = LaunchParams(params)
+        launch_params = cls.launch_params_class(params)
 
         if 'oauth_consumer_key' not in launch_params:
             raise InvalidLTIRequestError("oauth_consumer_key not found!")

--- a/tests/test_tool_provider.py
+++ b/tests/test_tool_provider.py
@@ -29,11 +29,7 @@ def create_tp(key=None, secret=None, lp=None, launch_url=None,
 class CustomLaunchParams(LaunchParams):
     def valid_param(self, param):
         result  = super(CustomLaunchParams, self).valid_param(param)
-        if not result:
-            if param in ['basiclti_submit', 'launch_url']:
-                result = True
-
-        return result
+        return result or param in ['basiclti_submit', 'launch_url']
 
 class CustomToolProvider(ToolProvider):
     launch_params_class = CustomLaunchParams


### PR DESCRIPTION
Here is my first attempt at handling non standard parameters.

In LaunchParams class I added a valid_params method. At the moment the default implementation just calls the module valid_param function. We could copy and paste the implementation of the valid_param function into the method and add a deprecation warning to the function if you want or we can just leave it as is.

At the moment I don't see a need to deprecate the original other than for cleanliness.

In the ToolProvider I just added a class attribute to define the LaunchParam class so that it can be overridden.

In the tests the create_tp function was hardcoded to use LaunchParams, I just changed that to use the LaunchParams from the ToolProvider Class.

I created a couple of custom test classes to test with

I added a new test that mimics the other tests but with custom parameters added 