### PR TITLE
Enable to_xml() method to append <blti:icon></blti:icon> node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ venv
 
 # pytest
 .cache
+.pytest_cache
 
 # Coverage
 .coverage*

--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,11 @@ configuration URL when registering your app with the LTI consumer.
             description = app_description
         )
 
+        # or you may need some additional LTI parameters
+        lti_tool_config.cartridge_bundle = 'BLTI001_Bundle'
+        lti_tool_config.cartridge_icon = 'BLTI001_Icon'
+        lti_tool_config.icon = 'http://www.example.com/icon.png'
+
         return HttpResponse(lti_tool_config.to_xml(), content_type='text/xml')
 
 

--- a/src/lti/tool_config.py
+++ b/src/lti/tool_config.py
@@ -214,6 +214,10 @@ class ToolConfig(object):
             option = etree.SubElement(root, '{%s}%s' % (NSMAP['blti'], key))
             option.text = getattr(self, key)
 
+        if getattr(self, 'icon'):
+            option = etree.SubElement(root, '{%s}%s' % (NSMAP['blti'], 'icon'))
+            option.text = getattr(self, 'icon')
+
         vendor_keys = ['name', 'code', 'description', 'url']
         if any('vendor_' + key for key in vendor_keys) or\
                 self.vendor_contact_email:

--- a/tests/test_tool_config.py
+++ b/tests/test_tool_config.py
@@ -8,6 +8,7 @@ CC_LTI_XML = b'''<?xml version="1.0" encoding="UTF-8"?>
     <blti:description>Description of boringness</blti:description>
     <blti:launch_url>http://www.example.com/lti</blti:launch_url>
     <blti:secure_launch_url>https://www.example.com/lti</blti:secure_launch_url>
+    <blti:icon>http://wil.to/_/beardslap.gif</blti:icon>
     <blti:vendor>
         <lticp:name>test.tool</lticp:name>
         <lticp:code>test</lticp:code>
@@ -43,6 +44,7 @@ CC_LTI_WITH_SUBOPTIONS_XML = b'''<?xml version="1.0" encoding="UTF-8"?>
     <blti:description>Description of boringness</blti:description>
     <blti:launch_url>http://www.example.com/lti</blti:launch_url>
     <blti:secure_launch_url>https://www.example.com/lti</blti:secure_launch_url>
+    <blti:icon>http://wil.to/_/beardslap.gif</blti:icon>
     <blti:vendor>
         <lticp:name>test.tool</lticp:name>
         <lticp:code>test</lticp:code>


### PR DESCRIPTION
LTI Specs gives us option to set URL for tool's icon using `<blti:icon>` parameter. That parameter is already defined in `ToolConfig` of this library, but it's not used with `to_xml()` method. I've added this optional feature, updated tests, and README file to reflect the changes.