### PR TITLE
Fix issue with cartridge_icon parsing from xml.

### DIFF
--- a/src/lti/tool_config.py
+++ b/src/lti/tool_config.py
@@ -130,8 +130,8 @@ class ToolConfig(object):
                 self.secure_icon = child.text
             if 'cartridge_bundle' in child.tag:
                 self.cartridge_bundle = child.attrib['identifierref']
-            if 'catridge_icon' in child.tag:
-                self.cartridge_icon = child.atrib['identifierref']
+            if 'cartridge_icon' in child.tag:
+                self.cartridge_icon = child.attrib['identifierref']
 
             if 'vendor' in child.tag:
                 # Parse vendor tag

--- a/tests/test_tool_config.py
+++ b/tests/test_tool_config.py
@@ -171,6 +171,13 @@ class TestToolConfig(unittest.TestCase):
         got = normalize_xml(config.to_xml())
         self.assertEqual(got, correct)
 
+    def test_can_parse_optional_config_parameters(self):
+        '''
+        Config should have cartridge_icon and blti:icon set
+        '''
+        config = ToolConfig.create_from_xml(CC_LTI_OPTIONAL_PARAMS_XML)
+        self.assertEqual(config.cartridge_icon, 'BLTI001_Icon')
+
     def test_read_xml_config(self):
         '''
         Should read an XML config.


### PR DESCRIPTION
Fix tag name for `cartridge_icon`. Fix attribute error.