### PR TITLE
Release 0.9.3

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,12 @@
+0.9.3 (2018-06-20)
+++++++++++++++++++
+
+* Check full tagname when parsing xml (#60)
+* Fix issue with cartridge_icon parsing from xml (#58)
+* Add icon to tool config xml (#57)
+* Handling Non-Standard LTI Params (#55)
+* tool_provider: Fix doc for post_read_result (#53)
+
 0.9.2 (2017-06-15)
 ++++++++++++++++++
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='lti',
-    version='0.9.2',
+    version='0.9.3',
     description='A python library for building and/or consuming LTI apps',
     long_description=open('README.rst', 'rb').read().decode('utf-8'),
     maintainer='Ryan Hiebert',


### PR DESCRIPTION
* Check full tagname when parsing xml (#60)
* Fix issue with cartridge_icon parsing from xml (#58)
* Add icon to tool config xml (#57)
* Handling Non-Standard LTI Params (#55)
* tool_provider: Fix doc for post_read_result (#53)

------

This is all that it takes to release, at least unless things have broken since I set it up. I set things up to automatically deploy when the build passes on a tag. So all we need to do is have a PR like this that bumps the version and gets the HISTORY file updated, and then merge and tag the new release, and the CI processes will take care of the rest.