### PR TITLE
Fixed the MutableMapping importation (DeprecationWarning since Py3.7)

### DIFF
--- a/src/lti/launch_params.py
+++ b/src/lti/launch_params.py
@@ -1,6 +1,8 @@
 import sys
-from collections.abc import MutableMapping
-
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 from . import DEFAULT_LTI_VERSION
 
 py = sys.version_info

--- a/src/lti/launch_params.py
+++ b/src/lti/launch_params.py
@@ -1,5 +1,5 @@
 import sys
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 from . import DEFAULT_LTI_VERSION
 


### PR DESCRIPTION
Hi,

I just updated a project in Python 3.7 using LTI as a dependency.
Since, the following warning pops :

```
/usr/local/lib/python3.7/dist-packages/lti/launch_params.py:2: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
     from collections import MutableMapping
```

This patch aims to import `MutableMapping` from `collections.abc` in first intention, then fallback to `collections` (current behavior) for the Python versions before 3.3.

Thanks for your work on LTI !