### PR TITLE
Handle MutableMapping deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - 2.7
   - 3.5
   - 3.6
+  - 3.7
+  - 3.8
 install: pip install tox-travis codecov
 script: tox
 after_success: codecov
@@ -18,11 +20,11 @@ deploy:
     secure: TQ0/wEA4Z96GcPPpW4+BwVLq1Oh8YDihD1ugelIwgqIfpVJNF3lSpahazocAn6Lu53Z+I+qReyFMLBpdKBZAQN4d8501V8X029uY7l2Dj7qyWsgOlJmud8BtJZizZ2jgmdg670sZSrEAipfxJ0Rm5f7ItrTWLEEDZG2FQ88T2Ao6CQuOejqqm+UP2AL9he+BjbKN4cOBiVDyYY4KaayzCwue02JMDjTrQdUUD2ebjCa1DuEMLlsiy0Qwvfi59GBM6TygF9Tp4r+S4oCSEP7IoEmOEdykG0vhRlnugMtItl4L/m1DGL/xoClBPHTRP29JJ6c4yaoC4CxH7uGbpeW1EKOrncNx2GxMLco17S7UiBmIQudrvMDSAeepj1BCPUK+QU++OZo9+ZVcA9sctMcz0EieCwh1gXeO8nXtlsbtDzwMUaHTI1C1voSDRXcYGs0UdayGqN/+Rxv26AmJUJymNmcCZdZTfKHR8KLmEmz9UX/RzXad/en9LtKPWZSmwXio/Lrv+EfScvm/Q0Lec6fz2rkiMHWrG4Bvs+4oN4/5wPqC/KqatEWEXIRF8//Ksq+ffhIthApMfvKkE5Y1OwSi5ShGGLntJusSgdB3nr/sy6xEVFR5qshTiISysnKb7cjjxI9S8cQ4lX9HpUNdY6XC0moK1LZwlSsz4hV8AT5aTHA=
   on:
     tags: true
-    python: 3.6
+    python: 3.8
     condition: $TOXENV != desc
   distributions: sdist bdist_wheel
 matrix:
   fast_finish: true
   include:
-    - python: 3.6
+    - python: 3.8
       env: TOXENV=desc

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/src/lti/launch_params.py
+++ b/src/lti/launch_params.py
@@ -1,5 +1,9 @@
 import sys
-from collections import MutableMapping
+
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 from . import DEFAULT_LTI_VERSION
 

--- a/src/lti/tool_config.py
+++ b/src/lti/tool_config.py
@@ -25,9 +25,9 @@ VALID_ATTRIBUTES = [
 
 NSMAP = {
     'blti': 'http://www.imsglobal.org/xsd/imsbasiclti_v1p0',
-    'xsi': "http://www.w3.org/2001/XMLSchema-instance",
-    'lticp': 'http://www.imsglobal.org/xsd/imslticp_v1p0',
     'lticm': 'http://www.imsglobal.org/xsd/imslticm_v1p0',
+    'lticp': 'http://www.imsglobal.org/xsd/imslticp_v1p0',
+    'xsi': "http://www.w3.org/2001/XMLSchema-instance",
 }
 
 

--- a/tests/test_tool_config.py
+++ b/tests/test_tool_config.py
@@ -187,6 +187,9 @@ class TestToolConfig(unittest.TestCase):
         Should read an XML config.
         '''
         config = ToolConfig.create_from_xml(CC_LTI_XML)
+        print(normalize_xml(config.to_xml()))
+        print("************")
+        print(normalize_xml(CC_LTI_XML))
         self.assertEqual(normalize_xml(config.to_xml()), normalize_xml(CC_LTI_XML))
 
     def test_invalid_config_xml(self):

--- a/tests/test_tool_config.py
+++ b/tests/test_tool_config.py
@@ -187,9 +187,6 @@ class TestToolConfig(unittest.TestCase):
         Should read an XML config.
         '''
         config = ToolConfig.create_from_xml(CC_LTI_XML)
-        print(normalize_xml(config.to_xml()))
-        print("************")
-        print(normalize_xml(CC_LTI_XML))
         self.assertEqual(normalize_xml(config.to_xml()), normalize_xml(CC_LTI_XML))
 
     def test_invalid_config_xml(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36
+envlist = py27, py35, py36, py37, py38
 
 [testenv]
 commands =


### PR DESCRIPTION
This closes #71. 

It also adds python 3.7 and 3.8 to tox and travis.