### PR TITLE
allow HTTP headers to be supplied for outcome request

### DIFF
--- a/src/lti/outcome_request.py
+++ b/src/lti/outcome_request.py
@@ -75,6 +75,7 @@ class OutcomeRequest(object):
 
             'text' : str text
             'url' : str url
+            'ltiLaunchUrl' : str url
         '''
         self.operation = REPLACE_REQUEST
         self.score = score
@@ -84,9 +85,9 @@ class OutcomeRequest(object):
                 error_msg = ('Dictionary result_data can only have one entry. '
                              '{0} entries were found.'.format(len(result_data)))
                 raise InvalidLTIConfigError(error_msg)
-            elif 'text' not in result_data and 'url' not in result_data:
+            elif 'text' not in result_data and 'url' not in result_data and 'ltiLaunchUrl' not in result_data:
                 error_msg = ('Dictionary result_data can only have the key '
-                             '"text" or the key "url".')
+                             '"text" or the key "url" or the key "ltiLaunchUrl".')
                 raise InvalidLTIConfigError(error_msg)
             else:
                 return self.post_outcome_request()
@@ -230,5 +231,8 @@ class OutcomeRequest(object):
             elif 'url' in self.result_data:
                 resultDataURL = etree.SubElement(resultData, 'url')
                 resultDataURL.text = self.result_data['url']
+            elif 'ltiLaunchUrl' in self.result_data:
+                resultDataLaunchURL = etree.SubElement(resultData, 'ltiLaunchUrl')
+                resultDataLaunchURL.text = self.result_data['ltiLaunchUrl']
 
         return etree.tostring(root, xml_declaration=True, encoding='utf-8')

--- a/src/lti/outcome_request.py
+++ b/src/lti/outcome_request.py
@@ -169,6 +169,14 @@ class OutcomeRequest(object):
                 sourcedGUID.sourcedId
             self.score = str(result.resultRecord.result.
                              resultScore.textString)
+
+            if len(resultData := result.find('resultRecord/result/resultData', root.nsmap)):
+                if r := resultData.find('text', root.nsmap):
+                    self.result_data = {'text': result}
+                elif r := resultData.find('url', root.nsmap):
+                    self.result_data = {'url': result}
+                elif r := resultData.find('ltiLaunchUrl', root.nsmap):
+                    self.result_data = {'ltiLaunchUrl': r}
         except:
             pass
 

--- a/src/lti/outcome_request.py
+++ b/src/lti/outcome_request.py
@@ -39,7 +39,7 @@ class OutcomeRequest(object):
     they each use it differently. The TP will use it to POST an OAuth-signed
     request to the TC. A TC will use it to parse such a request from a TP.
     '''
-    def __init__(self, opts=defaultdict(lambda: None), headers=None):
+    def __init__(self, opts=defaultdict(lambda: None), headers=None, requests_session=None):
         # Initialize all our accessors to None
         for attr in VALID_ATTRIBUTES:
             setattr(self, attr, None)
@@ -56,6 +56,7 @@ class OutcomeRequest(object):
         self.headers = CaseInsensitiveDict(headers or {})
         if "Content-Type" not in self.headers:
             self.headers['Content-type'] = 'application/xml'
+        self.requests_session = requests_session or requests.Session()
 
     @staticmethod
     def from_post_request(post_request, headers=None):
@@ -148,7 +149,7 @@ class OutcomeRequest(object):
                               signature_type=SIGNATURE_TYPE_AUTH_HEADER,
                               force_include_body=True, **kwargs)
 
-        resp = requests.post(self.lis_outcome_service_url, auth=header_oauth,
+        resp = self.requests_session.post(self.lis_outcome_service_url, auth=header_oauth,
                              data=self.generate_request_xml(),
                              headers=self.headers)
         outcome_resp = OutcomeResponse.from_post_response(resp, resp.content)

--- a/tests/test_outcome_request.py
+++ b/tests/test_outcome_request.py
@@ -111,7 +111,8 @@ class TestOutcomeRequest(unittest.TestCase):
         self.assertTrue(request.has_required_attributes())
 
     def test_post_outcome_request(self):
-        request = OutcomeRequest()
+        request_headers = {"User-Agent": "unit-test"}
+        request = OutcomeRequest(headers=request_headers)
         self.assertRaises(InvalidLTIConfigError, request.post_outcome_request)
         request.consumer_key = 'consumer'
         request.consumer_secret = 'secret'
@@ -126,6 +127,8 @@ class TestOutcomeRequest(unittest.TestCase):
         self.assertIsInstance(resp, OutcomeResponse)
         request = resp.post_response.request
         self.assertTrue('authorization' in request.headers)
+        self.assertEqual(request.headers.get('user-agent'), b"unit-test")
+        self.assertEqual(request.headers.get('content-type'), b"application/xml")
         auth_header = unquote(request.headers['authorization'].decode('utf-8'))
         correct = ('OAuth '
             'oauth_nonce="my_nonce", oauth_timestamp="1234567890", '
@@ -141,8 +144,11 @@ class TestOutcomeRequest(unittest.TestCase):
             data=REPLACE_RESULT_XML,
             content_type='application/xml'
         )
-        request = OutcomeRequest.from_post_request(post_request)
+        request_headers = {"User-Agent": "post-request", "Content-Type": "text/xml"}
+        request = OutcomeRequest.from_post_request(post_request, request_headers)
         self.assertEqual(request.operation, 'replaceResult')
         self.assertEqual(request.lis_result_sourcedid, '261-154-728-17-784')
         self.assertEqual(request.message_identifier, '123456789')
         self.assertEqual(request.score, '5')
+        self.assertEqual(request.headers.get('User-Agent'), "post-request")
+        self.assertEqual(request.headers.get('Content-Type'), "text/xml")


### PR DESCRIPTION
I need to be able to override the User-Agent in the POST request because an outcome service I'm reporting to is rejecting the default python-requests user agent.