### PR TITLE
ToolProvider: Fix for issue 74

### DIFF
--- a/src/lti/tool_provider.py
+++ b/src/lti/tool_provider.py
@@ -58,10 +58,12 @@ class ToolProvider(ToolBase):
             self.launch_headers
         )
 
-        if valid and not self.consumer_key and not self.consumer_secret:
+        if valid:
             # Gather the key and secret
-            self.consumer_key = self.launch_params['oauth_consumer_key']
-            self.consumer_secret = validator.secret
+            if not self.consumer_key:
+                self.consumer_key = self.launch_params['oauth_consumer_key']
+            if not self.consumer_secret:
+                self.consumer_secret = validator.secret
 
         return valid
 


### PR DESCRIPTION
[_c.f_ issue #74]

<hr>

In some cases, the `ToolProvider.consumer_secret` is not set. This prevents the signing of outcome requests' XML.

Code snippets below help reproduce the events.

- In a launch view:

```
def lti_launch(request):
    if request.method == "POST":
        tool_provider = DjangoToolProvider.from_django_request(request=request)
        # tool_provider.consumer_key was set from the oauth_consumer_key post parameter; consumer_secret is still None
        oauth_validator = SigOnlyRequestValidator()
        is_valid_oauth = tool_provider.is_valid_request(oauth_validator)    
        [...]
```

- In the method `ToolProvider.is_valid_request`:
```
validator = ProxyValidator(validator)
valid, request = endpoint.validate_request([...])
# At this point the proxy contains the secret in validator.secret, though the tool_provider.consumer_secret is still None
if valid and not self.consumer_key and not self.consumer_secret:     # ! Potentially faulty line ! Condition is False, so tool_provider.consumer_secret stays to None
    self.consumer_key = self.launch_params['oauth_consumer_key']
    self.consumer_secret = validator.secret
return valid
```

- Problems arise later on during the usage of the `ToolProvider` instance:
```
tool_provider.post_replace_result(score=1)    # unable to sign the request since consumer_secret is None (OutcomeRequest.has_required_attributes returns False)
```
<hr>

**Solution:**
In the method `ToolProvider.is_valid_request`, the condition should be formulated as:
```
if valid:
    # Gather the key and secret
    if not self.consumer_key: 
        self.consumer_key = self.launch_params['oauth_consumer_key']
    if not self.consumer_secret:
        self.consumer_secret = validator.secret
```
