### PR TITLE
Add support for Canvas ltiLaunchUrl in outcome request

### DIFF
--- a/src/lti/outcome_request.py
+++ b/src/lti/outcome_request.py
@@ -75,6 +75,7 @@ class OutcomeRequest(object):
 
             'text' : str text
             'url' : str url
+            'ltiLaunchUrl' : str url
         '''
         self.operation = REPLACE_REQUEST
         self.score = score
@@ -84,9 +85,9 @@ class OutcomeRequest(object):
                 error_msg = ('Dictionary result_data can only have one entry. '
                              '{0} entries were found.'.format(len(result_data)))
                 raise InvalidLTIConfigError(error_msg)
-            elif 'text' not in result_data and 'url' not in result_data:
+            elif 'text' not in result_data and 'url' not in result_data and 'ltiLaunchUrl' not in result_data:
                 error_msg = ('Dictionary result_data can only have the key '
-                             '"text" or the key "url".')
+                             '"text" or the key "url" or the key "ltiLaunchUrl".')
                 raise InvalidLTIConfigError(error_msg)
             else:
                 return self.post_outcome_request()
@@ -230,5 +231,8 @@ class OutcomeRequest(object):
             elif 'url' in self.result_data:
                 resultDataURL = etree.SubElement(resultData, 'url')
                 resultDataURL.text = self.result_data['url']
+            elif 'ltiLaunchUrl' in self.result_data:
+                resultDataLaunchURL = etree.SubElement(resultData, 'ltiLaunchUrl')
+                resultDataLaunchURL.text = self.result_data['ltiLaunchUrl']
 
         return etree.tostring(root, xml_declaration=True, encoding='utf-8')

--- a/src/lti/outcome_request.py
+++ b/src/lti/outcome_request.py
@@ -165,6 +165,14 @@ class OutcomeRequest(object):
                 sourcedGUID.sourcedId
             self.score = str(result.resultRecord.result.
                              resultScore.textString)
+
+            if len(resultData := result.find('resultRecord/result/resultData', root.nsmap)):
+                if r := resultData.find('text', root.nsmap):
+                    self.result_data = {'text': result}
+                elif r := resultData.find('url', root.nsmap):
+                    self.result_data = {'url': result}
+                elif r := resultData.find('ltiLaunchUrl', root.nsmap):
+                    self.result_data = {'ltiLaunchUrl': r}
         except:
             pass
 


### PR DESCRIPTION
Canvas LMS supports an extra field in the outcome request's resultData field called `ltiLaunchUrl` (in addition to the standard `text` and `url` fields). If present, Canvas will launch the URL as an LTI tool (while `url` just shows a page).

I need this in my application so I've added it in. It's non-standard though so you may not want to accept this. 

Also, the code could be cleaned up a bit more now that there's three possible fields in the resultData, and also there needs to be unit tests added for all of the resultData code.